### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/src/app/modules/library/components/podcast-search-page/podcast-search-page.component.ts
+++ b/src/app/modules/library/components/podcast-search-page/podcast-search-page.component.ts
@@ -75,7 +75,8 @@ export class PodcastSearchPageComponent {
 		} = {};
 		data.forEach(result => {
 			const url = new URL(result.url);
-			if (url.hostname.includes('feedburner.com')) {
+			const allowedHosts = ['feedburner.com', 'www.feedburner.com'];
+			if (!allowedHosts.includes(url.hostname)) {
 				return;
 			}
 			let podcast = collect[result.title];


### PR DESCRIPTION
Potential fix for [https://github.com/ffalt/jamberry/security/code-scanning/1](https://github.com/ffalt/jamberry/security/code-scanning/1)

To fix the issue, the code should validate the hostname against an explicit whitelist of allowed hosts. Instead of using `url.hostname.includes('feedburner.com')`, the hostname should be compared directly to `'feedburner.com'` or its subdomains using a strict equality check or a whitelist.

Steps to implement the fix:
1. Replace the substring check with a whitelist of allowed hostnames.
2. Use a strict comparison to ensure the hostname matches exactly or is a valid subdomain of `'feedburner.com'`.
3. Update the logic in the `buildSearchResults` method to use this whitelist.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
